### PR TITLE
chez-matchable: typo fix in the description value

### DIFF
--- a/pkgs/development/chez-modules/chez-matchable/default.nix
+++ b/pkgs/development/chez-modules/chez-matchable/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   meta = {
-    description = "This is a Library for ChezScheme providing the protable hygenic pattern matcher by Alex Shinn";
+    description = "This is a Library for ChezScheme providing the portable hygenic pattern matcher by Alex Shinn";
     homepage = "https://github.com/fedeinthemix/chez-matchable/";
     maintainers = [ stdenv.lib.maintainers.jitwit ];
     license = stdenv.lib.licenses.publicDomain;


### PR DESCRIPTION
This fixes the typo "protable" and changes it to "portable" in the meta-attribute. 
I found this typo while browsing around through search.nixos.org
